### PR TITLE
Improved Security; Cosmetic fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Visual Studio folder
+.vscode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,8 @@ int main(int argc, char* argv[]) {
 	vector<string> package_manager_list = { "apt-get", "xbps", "dnf", "yum", "zypper", "eopkg", "pacman", "emerge", "pkg", "chromebrew", "homebrew", "nix", "snap", "npm", "flatpak", "slapt-get", "pip3" };
 
 	// Get the path if the user has changed it with an enviroment variable
-	char* env_config_path = getenv("SYSGET_CONFIG_PATH");
-	char* env_custom_path = getenv("SYSGET_CUSTOM_PATH");
+	char* env_config_path = secure_getenv("SYSGET_CONFIG_PATH");
+	char* env_custom_path = secure_getenv("SYSGET_CUSTOM_PATH");
 
 	// Check if the enviroment variables aren't empty
 	if(env_config_path != NULL) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,19 @@
 
 char CONFIG_PATH[255] = "/etc/sysget";	// Needs to be NOT const so it can be changed if an enviroment variable set
 char CUSTOM_PATH[255] = "/etc/sysget_custom";
+const char *help_msg =
+	"Help of sysget\n"
+	"sysget [OPTION] [PACKAGE(S)]\n"
+	"\n"
+	"search [QUERY]\t\t\tsearch for a package in the resporitories\n"
+	"install [PACKAGE] [PACKAGE]\tinstall a package from the repos\n"
+	"remove [PACKAGE] [PACKAGE]\tremoves a package\n"
+	"autoremove\t\t\tremoves not needed packages (orphans)\n"
+	"update\t\t\t\tupdate the database\n"
+	"upgrade\t\t\t\tdo a system upgrade\n"
+	"upgrade [PACKAGE] [PACKAGE]\tupgrade a specific package\n"
+	"clean\t\t\t\tclean the download cache\n"
+	"set [NEW MANAGER]\t\tset a new package manager\n\n";
 
 using namespace std;
 
@@ -191,19 +204,7 @@ int main(int argc, char* argv[]) {
 
 	// Help
 	else if(cmd == "help") {
-		cout << "Help of sysget" << endl;
-		cout << "sysget [OPTION] [PACKAGE(S)]" << endl;
-		cout << endl;
-		cout << "search [QUERY]\t\t\tsearch for a package in the resporitories" << endl;
-		cout << "install [PACKAGE] [PACKAGE]\tinstall a package from the repos" << endl;
-		cout << "remove [PACKAGE] [PACKAGE]\tremoves a package" << endl;
-		cout << "autoremove\t\t\tremoves not needed packages (orphans)" << endl;
-		cout << "update\t\t\t\tupdate the database" << endl;
-		cout << "upgrade\t\t\t\tdo a system upgrade" << endl;
-		cout << "upgrade [PACKAGE] [PACKAGE]\tupgrade a specific package" << endl;
-		cout << "clean\t\t\t\tclean the download cache" << endl;
-		cout << "set [NEW MANAGER]\t\tset a new package manager" << endl;
-		cout << endl;
+		cout << help_msg;
 	}
 
 	else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,11 @@
 #include "packagemanager.hpp"
 #include "utils.hpp"
 
+// Use secure_getenv when compiling for Linux
+#ifdef __linux__
+	#define getenv secure_getenv
+#endif
+
 char CONFIG_PATH[255] = "/etc/sysget";	// Needs to be NOT const so it can be changed if an enviroment variable set
 char CUSTOM_PATH[255] = "/etc/sysget_custom";
 const char *help_msg =
@@ -27,8 +32,8 @@ int main(int argc, char* argv[]) {
 	vector<string> package_manager_list = { "apt-get", "xbps", "dnf", "yum", "zypper", "eopkg", "pacman", "emerge", "pkg", "chromebrew", "homebrew", "nix", "snap", "npm", "flatpak", "slapt-get", "pip3" };
 
 	// Get the path if the user has changed it with an enviroment variable
-	char* env_config_path = secure_getenv("SYSGET_CONFIG_PATH");
-	char* env_custom_path = secure_getenv("SYSGET_CUSTOM_PATH");
+	char* env_config_path = getenv("SYSGET_CONFIG_PATH");
+	char* env_custom_path = getenv("SYSGET_CUSTOM_PATH");
 
 	// Check if the enviroment variables aren't empty
 	if(env_config_path != NULL) {


### PR DESCRIPTION
Tested and compiled on `Fedora release 28 (Twenty Eight)`.


In this pull request I changed few things:

- Replaced `getenv` with `secure_getenv`.
  From the **Linux Programmer's Manual**:

  > The  `secure_getenv()` function is intended for use in general-purpose libraries **to avoid vulnerabilities** that could occur if **set-user-ID** or **set-group-ID programs accidentally trusted the environment.**
- Cosmetic fix. Just made a string that will contain the "help" message. In this way, it's easier to edit it.
  NOTE: Please, feel free to move that string where ever you like.
- Added the folder `.vscode` to the `.gitignore` to help who uses Visual Studio Code. 