### PR TITLE
Fix SIGSEGV crash when LANG not detected

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,8 +63,12 @@ std::vector<std::string> AboutCmds = {"about", "--about"};
 std::vector<std::string> VersionCmds = {"version", "--version"};
 
 int main(int argc, char* argv[]) {
-	std::string LangEnv = std::string(getenv("LANG"));
-	lang = sysget::language(LangEnv);
+	char* LangEnv = getenv("LANG");
+	
+	if (LangEnv == NULL) {
+		LangEnv = (char*)"en";
+	}
+	lang = sysget::language(std::string(LangEnv));
 	std::vector<std::string> PackageManagerList = sysget::GetPackageManagerList();
 
 	// Get the path if the user has changed it with an enviroment variable


### PR DESCRIPTION
'getenv()' returns NULL if the value passed is not found in the
enviroment, and because of the assumed behaviour as it stands,
this may crash -- we're trying to cast a NULL value to std::string
which of course will not work.

We can remedy this by checking for the NULL value and setting a
fallback value if needed.